### PR TITLE
Changed Lighttpd configuration to avoid syntax error on version 1.4.35-1...

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,8 +65,10 @@ resolver_timeout 5s;
 ssl.honor-cipher-order = "enable"
 ssl.cipher-list = "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4"
 ssl.use-compression = "disable"
-setenv.add-response-header = ("Strict-Transport-Security" =&gt; "max-age=63072000; <i>includeSubDomains</i>")
-setenv.add-response-header = ("X-Frame-Options" =&gt; "DENY")
+setenv.add-response-header = (
+    "Strict-Transport-Security" =&gt; "max-age=63072000; <i>includeSubDomains</i>",
+    "X-Frame-Options" =&gt; "DENY"
+)
 ssl.use-sslv2 = "disable"
 ssl.use-sslv3 = "disable"
             </pre><br />


### PR DESCRIPTION
I changed the lighttpd configuration to avoid syntax error on version 1.4.35-1. Using setenv.add-response-header as two assignment statements, caused the lighttpd to fail to start and combining them resolved it for me.

 Changes to be committed:
    modified:   index.html
