### PR TITLE
Note SSLCompression minimum version

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     function oldCrap() {
       document.getElementById("apacheconfig").innerHTML = 'SSLCipherSuite ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4 \n';
       document.getElementById("apacheconfig").innerHTML += 'SSLProtocol All -SSLv2 -SSLv3\n';
-      document.getElementById("apacheconfig").innerHTML += 'SSLCompression off\n';
+      document.getElementById("apacheconfig").innerHTML += 'SSLCompression off # Requires Apache >= 2.4\n';
       document.getElementById("apacheconfig").innerHTML += 'SSLHonorCipherOrder On\n';
       document.getElementById("apacheconfig").innerHTML += 'SSLUseStapling on # Requires Apache >= 2.4\n';
       document.getElementById("apacheconfig").innerHTML += 'SSLStaplingCache "shmcb:logs/stapling-cache(150000)\" # Requires >= Apache 2.4\n';
@@ -69,7 +69,7 @@
             <pre class="pre-trans" id="apacheconfig">
 SSLCipherSuite AES256+EECDH:AES256+EDH
 SSLProtocol All -SSLv2 -SSLv3
-SSLCompression off
+SSLCompression off # Requires Apache >= 2.4
 SSLHonorCipherOrder On
 SSLUseStapling on # Requires Apache >= 2.4
 SSLStaplingCache "shmcb:logs/stapling-cache(150000)" # Requires >= Apache 2.4


### PR DESCRIPTION
Citation: ["Available in httpd 2.4.3 and later"](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcompression)
