### PR TITLE
Remove builtin cache from nginx

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
       document.getElementById("nginxconfig").innerHTML = 'ssl_ciphers "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_protocols TLSv1 TLSv1.1 TLSv1.2;\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_prefer_server_ciphers on;\n';
-      document.getElementById("nginxconfig").innerHTML += 'ssl_session_cache  builtin:1000  shared:SSL:10m;\n';
+      document.getElementById("nginxconfig").innerHTML += 'ssl_session_cache shared:SSL:10m;\n';
       document.getElementById("nginxconfig").innerHTML += 'add_header Strict-Transport-Security "max-age=63072000; <i>includeSubDomains</i>";\n';
       document.getElementById("nginxconfig").innerHTML += 'add_header X-Frame-Options DENY;\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_stapling on; # Requires nginx >= 1.3.7\n';
@@ -84,7 +84,7 @@ Header always set X-Frame-Options DENY
 ssl_ciphers "AES256+EECDH:AES256+EDH";
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 ssl_prefer_server_ciphers on;
-ssl_session_cache  builtin:1000  shared:SSL:10m;
+ssl_session_cache shared:SSL:10m;
 add_header Strict-Transport-Security "max-age=63072000; <i>includeSubDomains</i>";
 add_header X-Frame-Options DENY;
 ssl_stapling on; # Requires nginx >= 1.3.7


### PR DESCRIPTION
> "Use of the built-in cache can cause memory fragmentation."
> "using only shared cache without the built-in cache should be more efficient."

http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache
