### PR TITLE
fix missing & broken X-Content-Type-Options

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
       document.getElementById("lighttpdconfig").innerHTML += 'ssl.use-compression = "disable"\n';
       document.getElementById("lighttpdconfig").innerHTML += 'setenv.add-response-header = ("Strict-Transport-Security" =&gt; "max-age=63072000; <i>includeSubDomains</i>")\n';
       document.getElementById("lighttpdconfig").innerHTML += 'setenv.add-response-header = ("X-Frame-Options" =&gt; "DENY")\n';
-      document.getElementById("lighttpdconfig").innerHTML += 'setenv.add-response-header = (X-Content-Type-Options" =&gt; "nosniff")\n';
+      document.getElementById("lighttpdconfig").innerHTML += 'setenv.add-response-header = ("X-Content-Type-Options" =&gt; "nosniff")\n';
       document.getElementById("lighttpdconfig").innerHTML += 'ssl.use-sslv2 = "disable"\n';
       document.getElementById("lighttpdconfig").innerHTML += 'ssl.use-sslv3 = "disable"\n';
 
@@ -78,6 +78,7 @@ SSLUseStapling on # Requires Apache >= 2.4
 SSLStaplingCache "shmcb:logs/stapling-cache(150000)" # Requires >= Apache 2.4
 Header always set Strict-Transport-Security "max-age=63072000; <i>includeSubDomains</i>"
 Header always set X-Frame-Options DENY
+Header always set X-Content-Type-Options nosniff
             </pre>
             <br />
             </div>
@@ -90,6 +91,7 @@ ssl_prefer_server_ciphers on;
 ssl_session_cache shared:SSL:10m;
 add_header Strict-Transport-Security "max-age=63072000; <i>includeSubDomains</i>";
 add_header X-Frame-Options DENY;
+add_header X-Content-Type-Options nosniff;
 ssl_stapling on; # Requires nginx >= 1.3.7
 ssl_stapling_verify on; # Requires nginx => 1.3.7
 resolver <i>$DNS-IP-1 $DNS-IP-2</i> valid=300s;
@@ -104,7 +106,8 @@ ssl.cipher-list = "AES256+EECDH:AES256+EDH"
 ssl.use-compression = "disable"
 setenv.add-response-header = (
     "Strict-Transport-Security" =&gt; "max-age=63072000; <i>includeSubDomains</i>",
-    "X-Frame-Options" =&gt; "DENY"
+    "X-Frame-Options" =&gt; "DENY",
+    "X-Content-Type-Options" =&gt; "nosniff"
 )
 ssl.use-sslv2 = "disable"
 ssl.use-sslv3 = "disable"


### PR DESCRIPTION
Missed default recommended settings. Also adds missing quote in backwards compatible `X-Content-Type-Options` settings.
