### PR TITLE
Use correct configuration option for ProFTPd

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@ openssl_options = +no_sslv2 +no_sslv3
         <pre class="pre-trans" id="proftpdconfig">
 TLSEngine on
 TLSLog /var/ftpd/tls.log
-TLSProtocol TLSv1.2
+TLSProtocol TLSv1
 TLSRequired on
 TLSCipherSuite AES128+EECDH:AES128+EDH
 TLSRSACertificateFile /etc/proftpd.cert


### PR DESCRIPTION
The current setup is incorrect, according to http://www.proftpd.org/docs/directives/linked/config_ref_TLSProtocol.html I corrected the setup.