### PR TITLE
Add ssl_dh_parameters_length for Dovecot > 2.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,7 +273,7 @@ ssl_key = &lt;/etc/dovecot.key
 ssl_protocols = !SSLv2 !SSLv3
 ssl_cipher_list = AES128+EECDH:AES128+EDH
 ssl_prefer_server_ciphers = yes # >Dovecot 2.2.6
-ssl_dh_parameters_length = 2048 # >Dovecot 2.2
+ssl_dh_parameters_length = 4096 # >Dovecot 2.2
         </pre>
         <br />
       </div>

--- a/index.html
+++ b/index.html
@@ -273,6 +273,7 @@ ssl_key = &lt;/etc/dovecot.key
 ssl_protocols = !SSLv2 !SSLv3
 ssl_cipher_list = AES128+EECDH:AES128+EDH
 ssl_prefer_server_ciphers = yes # >Dovecot 2.2.6
+ssl_dh_parameters_length = 2048 # >Dovecot 2.2
         </pre>
         <br />
       </div>


### PR DESCRIPTION
Dovecot > 2.2 supports specifying the length of DH parameters.  By
default, it generates 512 and 1024 bit DH keys.

http://wiki2.dovecot.org/SSL/DovecotConfiguration#SSL_security_settings