### PR TITLE
Make greater-than-or-equal-to consistent.

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
       document.getElementById("nginxconfig").innerHTML += 'add_header X-Content-Type-Options nosniff;\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_session_tickets off;\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_stapling on; # Requires nginx >= 1.3.7\n';
-      document.getElementById("nginxconfig").innerHTML += 'ssl_stapling_verify on; # Requires nginx => 1.3.7\n';
+      document.getElementById("nginxconfig").innerHTML += 'ssl_stapling_verify on; # Requires nginx >= 1.3.7\n';
       document.getElementById("nginxconfig").innerHTML += 'resolver <i>$DNS-IP-1 $DNS-IP-2</i> valid=300s;\n';
       document.getElementById("nginxconfig").innerHTML += 'resolver_timeout 5s;\n';
 


### PR DESCRIPTION
It both reads correctly and scans nicely.