### PR TITLE
ssl_session_tickets is relatively new

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@ ssl_session_cache shared:SSL:10m;
 add_header Strict-Transport-Security "max-age=63072000; <i>includeSubdomains</i>; preload";
 add_header X-Frame-Options DENY;
 add_header X-Content-Type-Options nosniff;
-ssl_session_tickets off;
+ssl_session_tickets off; # Requires nginx >= 1.5.9
 ssl_stapling on; # Requires nginx >= 1.3.7
 ssl_stapling_verify on; # Requires nginx => 1.3.7
 resolver <i>$DNS-IP-1 $DNS-IP-2</i> valid=300s;


### PR DESCRIPTION
Indicate minimum version for ssl_session_tickets (see: http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets), like other features with even lower minimum versions like stapling