### PR TITLE
Fixing zarafa formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,9 +288,11 @@ server_ssl_ciphers = ALL:!LOW:!SSLv2:!SSLv3:!EXP:!aNULL
 server_ssl_prefer_server_ciphers = yes or no
         </pre>
         <h3>High security</h3>
+        <pre class="pre-trans" id="zarafahighconfig">
 server_ssl_protocols = !SSLv2 !SSLv3   # >= Debian 7 / CentOS 7
 server_ssl_ciphers = EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH EDH+aRSA:RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS
-server_ssl_prefer_server_ciphers = yes or no﻿
+server_ssl_prefer_server_ciphers = yes or no
+        </pre>
         <br />
       </div>
     </div>


### PR DESCRIPTION
Zarafa high security was missing the `<pre>` tags