### PR TITLE
Move SSLSessionTickets to Apache 2.4 section

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,10 +25,10 @@
       document.getElementById("apacheconfig").innerHTML += 'Header always set X-Frame-Options DENY\n';
       document.getElementById("apacheconfig").innerHTML += 'Header always set X-Content-Type-Options nosniff\n';
       document.getElementById("apacheconfig").innerHTML += '# Requires Apache >= 2.4 \n';
-      document.getElementById("apacheconfig").innerHTML += 'SSLUseStapling on \n';
-      document.getElementById("apacheconfig").innerHTML += 'SSLSessionTickets Off \n';
-      document.getElementById("apacheconfig").innerHTML += 'SSLStaplingCache "shmcb:logs/stapling-cache(150000)\"\n';
       document.getElementById("apacheconfig").innerHTML += 'SSLCompression off\n';
+      document.getElementById("apacheconfig").innerHTML += 'SSLSessionTickets Off \n';
+      document.getElementById("apacheconfig").innerHTML += 'SSLUseStapling on \n';
+      document.getElementById("apacheconfig").innerHTML += 'SSLStaplingCache "shmcb:logs/stapling-cache(150000)\"\n';
 
 
       document.getElementById("nginxconfig").innerHTML = 'ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:ECDHE-RSA-AES128-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA128:DHE-RSA-AES128-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA128:ECDHE-RSA-AES128-SHA384:ECDHE-RSA-AES128-SHA128:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA128:DHE-RSA-AES128-SHA128:DHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA384:AES128-GCM-SHA128:AES128-SHA128:AES128-SHA128:AES128-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";\n';
@@ -76,12 +76,12 @@
 SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
 SSLProtocol All -SSLv2 -SSLv3
 SSLHonorCipherOrder On
-SSLSessionTickets Off
 Header always set Strict-Transport-Security "max-age=63072000; <i>includeSubdomains</i>; preload"
 Header always set X-Frame-Options DENY
 Header always set X-Content-Type-Options nosniff
 # Requires Apache >= 2.4
 SSLCompression off 
+SSLSessionTickets Off
 SSLUseStapling on 
 SSLStaplingCache "shmcb:logs/stapling-cache(150000)" 
             </pre>


### PR DESCRIPTION
SSLSessionTickets was already in the Apache 2.4 section in the compatibility configuration; Also, reorder the compatibility lines to match the cleaner grouping of the strong cipher section.