### PR TITLE
Add ssl_ecdh_curve to (reordered) nginx options.

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,18 +88,19 @@ SSLStaplingCache "shmcb:logs/stapling-cache(150000)"
             <div class="col-md-4 column">
             <h2>nginx</h2>
                 <pre class="pre-trans" id="nginxconfig">
-ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 ssl_prefer_server_ciphers on;
+ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
 ssl_session_cache shared:SSL:10m;
-add_header Strict-Transport-Security "max-age=63072000; <i>includeSubdomains</i>; preload";
-add_header X-Frame-Options DENY;
-add_header X-Content-Type-Options nosniff;
 ssl_session_tickets off; # Requires nginx >= 1.5.9
 ssl_stapling on; # Requires nginx >= 1.3.7
 ssl_stapling_verify on; # Requires nginx => 1.3.7
 resolver <i>$DNS-IP-1 $DNS-IP-2</i> valid=300s;
 resolver_timeout 5s;
+add_header Strict-Transport-Security "max-age=63072000; <i>includeSubdomains</i>; preload";
+add_header X-Frame-Options DENY;
+add_header X-Content-Type-Options nosniff;
                 </pre><br />
             </div>
             <div class="col-md-4 column">


### PR DESCRIPTION
This specifies the curve to use in EC ciphersuites. The default is `prime256v1`, also known as NIST P-256.
However, browsers can handle `secp384r1`, also known as NIST P-384, as well, which is stronger.
Most browsers can also handle `secp521r1`, also known as NIST P-521, but Internet Explorer 8- finds itself lacking support there.

Also reorder the nginx options a bit for logical grouping purposes.