### PR TITLE
nginx: Always send headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,9 +35,10 @@
       document.getElementById("nginxconfig").innerHTML += 'ssl_protocols TLSv1 TLSv1.1 TLSv1.2;\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_prefer_server_ciphers on;\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_session_cache shared:SSL:10m;\n';
-      document.getElementById("nginxconfig").innerHTML += 'add_header Strict-Transport-Security "max-age=63072000; <i>includeSubdomains</i>; preload";\n';
-      document.getElementById("nginxconfig").innerHTML += 'add_header X-Frame-Options DENY;\n';
-      document.getElementById("nginxconfig").innerHTML += 'add_header X-Content-Type-Options nosniff;\n';
+      document.getElementById("nginxconfig").innerHTML += '# 'always' requires nginx >= 1.7.5, see http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header'
+      document.getElementById("nginxconfig").innerHTML += 'add_header Strict-Transport-Security "max-age=63072000; <i>includeSubdomains</i>; preload" always;\n';
+      document.getElementById("nginxconfig").innerHTML += 'add_header X-Frame-Options DENY always;\n';
+      document.getElementById("nginxconfig").innerHTML += 'add_header X-Content-Type-Options nosniff always;\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_session_tickets off;\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_stapling on; # Requires nginx >= 1.3.7\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_stapling_verify on; # Requires nginx >= 1.3.7\n';


### PR DESCRIPTION
By default, nginx "[a]dds the specified field to a response header provided
that the response code equals 200, 201, 204, 206, 301, 302, 303, 304, or 307."
The headers should be sent for other response codes too, especially HSTS.