### PR TITLE
Session tickets only available from Apache 2.4.11 on

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,9 +79,10 @@ Header always set X-Frame-Options DENY
 Header always set X-Content-Type-Options nosniff
 # Requires Apache >= 2.4
 SSLCompression off 
-SSLSessionTickets Off
 SSLUseStapling on 
 SSLStaplingCache "shmcb:logs/stapling-cache(150000)" 
+# Requires Apache >= 2.4.11
+SSLSessionTickets Off
             </pre>
             <br />
             </div>


### PR DESCRIPTION
see https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslsessiontickets