### PR TITLE
Fixed unescaped single-quote that made oldCrap() fail

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       document.getElementById("nginxconfig").innerHTML += 'ssl_protocols TLSv1 TLSv1.1 TLSv1.2;\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_prefer_server_ciphers on;\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_session_cache shared:SSL:10m;\n';
-      document.getElementById("nginxconfig").innerHTML += '# 'always' requires nginx >= 1.7.5, see http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header'
+      document.getElementById("nginxconfig").innerHTML += '# \'always\' requires nginx >= 1.7.5, see http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header'
       document.getElementById("nginxconfig").innerHTML += 'add_header Strict-Transport-Security "max-age=63072000; <i>includeSubdomains</i>; preload" always;\n';
       document.getElementById("nginxconfig").innerHTML += 'add_header X-Frame-Options DENY always;\n';
       document.getElementById("nginxconfig").innerHTML += 'add_header X-Content-Type-Options nosniff always;\n';


### PR DESCRIPTION
oldCrap() wasn't working on the production cipherli.st. This fixes it!