### PR TITLE
Wrong Nginx version and missing OpenSSL requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ SSLSessionTickets Off
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 ssl_prefer_server_ciphers on;
 ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
-ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
+ssl_ecdh_curve secp384r1; # Requires >= 1.11.0 and OpenSSL >= 1.0.2
 ssl_session_cache shared:SSL:10m;
 ssl_session_tickets off; # Requires nginx >= 1.5.9
 ssl_stapling on; # Requires nginx >= 1.3.7


### PR DESCRIPTION
Hey,

the Nginx version 1.11.0 is the first version which supports ssl_ecdh_curve not 1.1.0 =)
Additionally this function requires OpenSSL >= 1.0.2 

See http://nginx.org/en/CHANGES 
"Changes with nginx 1.11.0                                        24 May 2016
    *) Feature: the "ssl_ecdh_curve" directive now allows specifying a list
       of curves when using OpenSSL 1.0.2 or newer; by default a list built
       into OpenSSL is used."
