### PR TITLE
Added comment for "ssl_session_tickets off"

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
       document.getElementById("nginxconfig").innerHTML += 'add_header Strict-Transport-Security "max-age=63072000; <i>includeSubdomains</i>; preload" always;\n';
       document.getElementById("nginxconfig").innerHTML += 'add_header X-Frame-Options DENY always;\n';
       document.getElementById("nginxconfig").innerHTML += 'add_header X-Content-Type-Options nosniff always;\n';
-      document.getElementById("nginxconfig").innerHTML += 'ssl_session_tickets off;\n';
+      document.getElementById("nginxconfig").innerHTML += 'ssl_session_tickets off; # you need to enable this for all ssl sites on the same server, see https://goo.gl/40Pr0w\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_stapling on; # Requires nginx >= 1.3.7\n';
       document.getElementById("nginxconfig").innerHTML += 'ssl_stapling_verify on; # Requires nginx >= 1.3.7\n';
       document.getElementById("nginxconfig").innerHTML += 'resolver <i>$DNS-IP-1 $DNS-IP-2</i> valid=300s;\n';


### PR DESCRIPTION
If you have multiple ssl hosts defined on one nginx server, you need to set "ssl_session_tickets off" for all hosts, otherwise connections to sites set to "off" will fail to work with the error "gnutls_handshake() failed: An unexpected TLS packet was received", but nginx will not report any errors on "nginx -t"