### PR TITLE
Update index.html (Nginx)

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@ SSLSessionTickets Off
                 <pre class="pre-trans" id="nginxconfig">
 ssl_protocols TLSv1.2;
 ssl_prefer_server_ciphers on;
-ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:!DH";
 ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
 ssl_session_cache shared:SSL:10m;
 ssl_session_tickets off; # Requires nginx >= 1.5.9


### PR DESCRIPTION
ssl_ciphers Update 

SSLLabs message with the current configuration of Nginx: "This server supports weak Diffie-Hellman (DH) key exchange parameters." --> "B"

The option:`!DH` solve the problem and get "A+"

Regards