### PR TITLE
Whitespace breaks server_ssl_ciphers

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,7 +302,7 @@ server_ssl_prefer_server_ciphers = yes or no
         <h3>High security</h3>
         <pre class="pre-trans" id="zarafahighconfig">
 server_ssl_protocols = !SSLv2 !SSLv3 !TLSv1 !TLSv1.1  # >= Debian 7 / CentOS 7
-server_ssl_ciphers = EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH EDH+aRSA:RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS
+server_ssl_ciphers = EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS
 server_ssl_prefer_server_ciphers = yes or no
         </pre>
         <br />


### PR DESCRIPTION
As it can be seen in the first ssl_ciphers line at https://security.stackexchange.com/a/54877 the whitespace between "EECDH EDH+aRSA" breaks the server_ssl_ciphers setting for zarafa high security config, it should be "EECDH:EDH+aRSA"