### PR TITLE
Remove 'hmac-ripemd160' from the MAC list

### DIFF
--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@ HostKey /etc/ssh/ssh_host_ed25519_key
 HostKey /etc/ssh/ssh_host_rsa_key
 KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
         </pre>
         <br />
       </div>
@@ -379,7 +379,7 @@ Host github.com
 Host *
   ConnectTimeout 30
   KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
-  MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com
+  MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
   Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
   ServerAliveInterval 10
   ControlMaster auto


### PR DESCRIPTION
This MAC was removed from OpenSSH in version 7.6 leading to breakage
(daemon doesn't start anymore).
For this reason it should be removed from the list.

The change for OpenSSH 7.6 is visible on http://lists.mindrot.org/pipermail/openssh-unix-dev/2017-October/036296.html

I choosed to remove the MAC from the list in both server and client side.
Server-side, it was breaking the daemon that just refused to start after updating to 7.6.
Client-sied would be less of an issue I guess, but I think it's better to have the same on both side.

The other solution if you think keeping this is better is to add a warning for people using version 7.6 or higher.