### PR TITLE
Remove 3DES support

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ SSLSessionTickets Off
 ssl_protocols TLSv1.3;# Requires nginx >= 1.13.0 else use TLSv1.2
 ssl_prefer_server_ciphers on; 
 ssl_dhparam /etc/nginx/dhparam.pem; # openssl dhparam -out /etc/nginx/dhparam.pem 4096
-ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
+ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:!3DES;
 ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
 ssl_session_timeout  10m;
 ssl_session_cache shared:SSL:10m;


### PR DESCRIPTION
This is vulnerable to the [Sweet32](https://sweet32.info/) attack and is flagged by a number of automated scanning tools.