### PR TITLE
Add 'always' flag to nginx add_header directives

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,12 +101,13 @@ ssl_session_tickets off; # Requires nginx >= 1.5.9
 ssl_stapling on; # Requires nginx >= 1.3.7
 ssl_stapling_verify on; # Requires nginx => 1.3.7
 resolver <i>$DNS-IP-1 $DNS-IP-2</i> valid=300s;
-resolver_timeout 5s; 
-add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
-add_header X-Frame-Options DENY;
-add_header X-Content-Type-Options nosniff;
-add_header X-XSS-Protection "1; mode=block";
-add_header X-Robots-Tag none; 
+resolver_timeout 5s;
+# 'always' requires nginx >= 1.7.5, see http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+add_header X-Frame-Options DENY always;
+add_header X-Content-Type-Options nosniff always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header X-Robots-Tag none always;
                 </pre><br />
             </div>
             <div class="col-md-4 column">


### PR DESCRIPTION
The cipher suite for legacy/old software already uses the `always` flag ([here](https://github.com/fnkr/cipherli.st/blob/3816f82ead52b719d480c71f648206eb594fbc1e/index.html#L38-L41)), the strong cipher suite should use it too.