### PR TITLE
Update README to explain that website is gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Cipherli.st
 
-See [https://cipherli.st](https://cipherli.st)
+Former code for [https://cipherli.st](https://cipherli.st).
+
+We now recommend that you use [Mozilla's SSL/TLS documentation](https://wiki.mozilla.org/Security/Server_Side_TLS) (and their [configuration generator](https://mozilla.github.io/server-side-tls/ssl-config-generator/)).


### PR DESCRIPTION
Since the website for cipherli.st now redirects to the Mozilla Wiki, this README should explain that too.