### PR TITLE
Postfix: Enforce server cipher order

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,7 @@ smtpd_tls_mandatory_protocols = !SSLv2,!SSLv3,!TLSv1,!TLSv1.1
 smtpd_tls_protocols=!SSLv2,!SSLv3,!TLSv1,!TLSv1.1
 smtpd_tls_mandatory_ciphers = medium
 tls_medium_cipherlist = AES128+EECDH:AES128+EDH
+tls_preempt_cipherlist = yes
         </pre>
         <br />
       </div>


### PR DESCRIPTION
Added the Postfix [`tls_preempt_cipherlist yes`](http://www.postfix.org/postconf.5.html#tls_preempt_cipherlist) setting (which is equivalent to Apache's [`SSLHonorCipherOrder On`](https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslhonorcipherorder) setting).