### PR TITLE
Force DH keysize to 2048 in HAProxy.cfg

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,6 +193,7 @@ ssl.use-sslv3 = "disable"
 global
    ssl-default-bind-options no-sslv3 no-tls-tickets force-tlsv12
    ssl-default-bind-ciphers AES128+EECDH:AES128+EDH
+   tune.ssl.default-dh-param 2048
 
 frontend http-in
       mode http


### PR DESCRIPTION
Some certs do not require 2048 DH key size so HAProxy will default to 1024 unless told otherwise.

See https://cbonte.github.io/haproxy-dconv/1.5/configuration.html#tune.ssl.default-dh-param