### PR TITLE
Update Legacy software version ranges to those not supporting TLS 1.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@ ssl.use-sslv3 = "disable"
             </div>
             <div class="col-md-10 col-md-offset-1" id="oldcrap">
                 <br >
-                <p>Do you need to (or are forced to) support old / legacy software like IE &lt; 9, Android &lt; 2.2 or Java &lt; 6? <a href="#" onclick="JavaScript:oldCrap(); return false;">Yes, give me a ciphersuite that works with legacy / old software.</a></p>
+                <p>Do you need to (or are forced to) support old / legacy software like IE &lt; 11, Android &lt; 4.4 or Java &lt; 8? <a href="#" onclick="JavaScript:oldCrap(); return false;">Yes, give me a ciphersuite that works with legacy / old software.</a></p>
             </div>
             <div class="col-md-10 col-md-offset-1">
               <p><a href="https://tls.so/"><h3>Test your SSL config</h3></a>.</p>


### PR DESCRIPTION
The current configuration only allows TLS 1.2, which is not supported

* in IE < 11 [1],
* Android < 4.4 [2] and
* Java < 8 [3]:

[1] https://www.ssllabs.com/ssltest/viewClient.html?name=IE&version=8%2d10&platform=Win%207&key=113
[2] https://www.ssllabs.com/ssltest/viewClient.html?name=Android&version=4.3&key=61
[3] https://www.ssllabs.com/ssltest/viewClient.html?name=Java&version=7u25&key=26

See [Qualys SSL ServerTest for cipherli.st](https://www.ssllabs.com/ssltest/analyze.html?d=cipherli.st&s=2a03%3ab0c0%3a3%3ad0%3a0%3a0%3a39a%3a5001):
![grafik](https://user-images.githubusercontent.com/495429/46525284-77c1d080-c88b-11e8-8b5d-12a3c58559fa.png)