### PR TITLE
Update haproxy curves preference

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@ frontend https-in
     option httpclose
     rspadd Strict-Transport-Security:\ max-age=31536000;\ includeSubDomains;\ preload
     rspadd X-Frame-Options:\ DENY
-    bind 192.0.2.10:443 ssl crt /etc/haproxy/haproxy.pem ciphers AES128+EECDH:AES128+EDH force-tlsv12 no-sslv3
+    bind 192.0.2.10:443 ssl crt /etc/haproxy/haproxy.pem curves X25519:P-256 ciphers AES128+EECDH:AES128+EDH force-tlsv12 no-sslv3
         </pre>
         <br />
       </div>


### PR DESCRIPTION
Added "curves X25519:P-256" to indicate server preference for the standard curve in TLS 1.3 which is more secure according to [safecurves.cr.yp.to](https://safecurves.cr.yp.to/). See example in the [HAProxy Configuration Manual](https://www.haproxy.org/download/1.8/doc/configuration.txt).