### PR TITLE
Remove/Replace CBC ciphers (due to new POODLE)

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@ SSLSessionTickets Off
 ssl_protocols TLSv1.3;# Requires nginx >= 1.13.0 else use TLSv1.2
 ssl_prefer_server_ciphers on; 
 ssl_dhparam /etc/nginx/dhparam.pem; # openssl dhparam -out /etc/nginx/dhparam.pem 4096
-ssl_ciphers ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384;
+ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
 ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
 ssl_session_timeout  10m;
 ssl_session_cache shared:SSL:10m;

--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@ ssl_dh = &lt;/etc/dhparam.pem # openssl dhparam -out /etc/dhparam.pem 4096
       <div class="col-md-6 column">
           <h2>Hitch TLS Proxy</h2>
           <pre class="pre-trans" id="hitchconfig">
-ciphers = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"
+ciphers = "EECDH+AESGCM:EDH+AESGCM"
 prefer-server-ciphers = on
           </pre>
       </div>

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
             <div class="col-md-4 column">
             <h2>Apache</h2>
             <pre class="pre-trans" id="apacheconfig">
-SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
+SSLCipherSuite EECDH+AESGCM:EDH+AESGCM
 # Requires Apache 2.4.36 & OpenSSL 1.1.1
 SSLProtocol -all +TLSv1.3 +TLSv1.2
 SSLOpenSSLConfCmd Curves X25519:secp521r1:secp384r1:prime256v1
@@ -116,7 +116,7 @@ add_header X-XSS-Protection "1; mode=block";
             <h2>Lighttpd</h2>
                 <pre class="pre-trans" id="lighttpdconfig">
 ssl.honor-cipher-order = "enable"
-ssl.cipher-list = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"
+ssl.cipher-list = "EECDH+AESGCM:EDH+AESGCM"
 ssl.use-compression = "disable"
 ssl.dh-file = "/etc/lighttpd/dhparam.pem" # openssl dhparam -out /etc/lighttpd/dhparam.pem 4096
 setenv.add-response-header = (
@@ -199,7 +199,7 @@ ssl.ec-curve = "secp384r1"
         <pre class="pre-trans" id="haproxyconfig">
 global
    ssl-default-bind-options no-sslv3 no-tls-tickets force-tlsv12
-   ssl-default-bind-ciphers AES128+EECDH:AES128+EDH
+   ssl-default-bind-ciphers EECDH+AESGCM:EDH+AESGCM
    tune.ssl.default-dh-param 2048
 
 frontend http-in
@@ -235,7 +235,7 @@ smtpd_tls_key_file = /etc/ssl/postfix.key
 smtpd_tls_mandatory_protocols = !SSLv2,!SSLv3,!TLSv1,!TLSv1.1
 smtpd_tls_protocols = !SSLv2,!SSLv3,!TLSv1,!TLSv1.1
 smtpd_tls_mandatory_ciphers = medium
-tls_medium_cipherlist = AES128+EECDH:AES128+EDH
+tls_medium_cipherlist = EECDH+AESGCM:EDH+AESGCM
 tls_preempt_cipherlist = yes
         </pre>
         <br />
@@ -248,7 +248,7 @@ tls_preempt_cipherlist = yes
 tls_certificate = /etc/exim.cert
 tls_privatekey = /etc/exim.key
 tls_advertise_hosts = *
-tls_require_ciphers = AES128+EECDH:AES128+EDH
+tls_require_ciphers = EECDH+AESGCM:EDH+AESGCM
 openssl_options = +no_sslv2 +no_sslv3
         </pre>
         <br />
@@ -269,7 +269,7 @@ TLSEngine on
 TLSLog /var/ftpd/tls.log
 TLSProtocol TLSv1.2
 TLSRequired on
-TLSCipherSuite AES128+EECDH:AES128+EDH
+TLSCipherSuite EECDH+AESGCM:EDH+AESGCM
 TLSRSACertificateFile /etc/proftpd.cert
 TLSRSACertificateKeyFile /etc/proftpd.key
         </pre>
@@ -283,7 +283,7 @@ ssl = yes
 ssl_cert = &lt;/etc/dovecot.cert
 ssl_key = &lt;/etc/dovecot.key
 ssl_min_protocol = TLSv1.2
-ssl_cipher_list = AES128+EECDH:AES128+EDH
+ssl_cipher_list = EECDH+AESGCM:EDH+AESGCM
 ssl_prefer_server_ciphers = yes
 ssl_dh = &lt;/etc/dhparam.pem # openssl dhparam -out /etc/dhparam.pem 4096
         </pre>
@@ -310,7 +310,7 @@ server_ssl_prefer_server_ciphers = yes or no
         <h3>High security</h3>
         <pre class="pre-trans" id="zarafahighconfig">
 server_ssl_protocols = !SSLv2 !SSLv3 !TLSv1 !TLSv1.1  # >= Debian 7 / CentOS 7
-server_ssl_ciphers = EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS
+server_ssl_ciphers = EECDH+AESGCM:EDH+AESGCM
 server_ssl_prefer_server_ciphers = yes or no
         </pre>
         <br />
@@ -327,7 +327,7 @@ server_ssl_prefer_server_ciphers = yes or no
 ssl-ca=/etc/mysql-ssl/ca-cert.pem
 ssl-cert=/etc/mysql-ssl/server-cert.pem
 ssl-key=/etc/mysql-ssl/server-key.pem
-ssl-cipher=AES128+EECDH:AES128+EDH
+ssl-cipher=EECDH+AESGCM:EDH+AESGCM
 # replication:
 GRANT REPLICATION SLAVE ON *.* to ‘repl’@’%’ REQUIRE SSL;
 STOP SLAVE;
@@ -345,7 +345,7 @@ SHOW SLAVE STATUS\G;
       <div class="col-md-6 column">
         <h2>DirectAdmin</h2>
         <pre class="pre-trans" id="directadminconfig">
-ssl_cipher=AES128+EECDH:AES128+EDH
+ssl_cipher=EECDH+AESGCM:EDH+AESGCM
 SSL=1
 cacert=/usr/local/directadmin/conf/cacert.pem
 cakey=/usr/local/directadmin/conf/cakey.pem
@@ -359,7 +359,7 @@ carootcert=/usr/local/directadmin/conf/carootcert.pem
         <h2>Postgresql</h2>
         <pre class="pre-trans" id="postgresconfig">
 ssl = on
-ssl_ciphers = 'AES128+EECDH:AES128+EDH'
+ssl_ciphers = 'EECDH+AESGCM:EDH+AESGCM'
 password_encryption = on
         </pre>
         <br />
@@ -421,9 +421,7 @@ func main() {
         PreferServerCipherSuites: true,
         CipherSuites: []uint16{
             tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-            tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
             tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
         },
     }
     srv := &amp;http.Server{

--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@ frontend https-in
     option httpclose
     rspadd Strict-Transport-Security:\ max-age=31536000;\ includeSubDomains;\ preload
     rspadd X-Frame-Options:\ DENY
-    bind $YOUR_IP:443 ssl crt /etc/haproxy/haproxy.pem ciphers AES128+EECDH:AES128+EDH force-tlsv12 no-sslv3
+    bind $YOUR_IP:443 ssl crt /etc/haproxy/haproxy.pem ciphers EECDH+AESGCM:EDH+AESGCM force-tlsv12 no-sslv3
         </pre>
         <br />
       </div>


### PR DESCRIPTION
Remove/Replace CBC ciphers due to Zombie POODLE and GOLDENDOODLE, for details see https://blog.qualys.com/technology/2019/04/22/zombie-poodle-and-goldendoodle-vulnerabilities

With that align all configs on a common openssl cipher list with AESGCM instead of AESGCM / AES256 or AES128.